### PR TITLE
ci: deploy game to GitHub Pages

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -2,6 +2,8 @@ name: Build and deploy GitHub Pages
 
 on:
   push:
+    branches: [main]
+  pull_request:
   workflow_dispatch:
 
 permissions:
@@ -41,6 +43,7 @@ jobs:
           path: dist
 
   deploy:
+    if: github.event_name != 'pull_request' && github.ref == 'refs/heads/main'
     needs: build
     runs-on: ubuntu-latest
     environment:

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -1,0 +1,52 @@
+name: Build and deploy GitHub Pages
+
+on:
+  push:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: pages
+  cancel-in-progress: true
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 24
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Build
+        run: npm run build
+
+      - name: Configure Pages
+        uses: actions/configure-pages@v5
+
+      - name: Upload Pages artifact
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: dist
+
+  deploy:
+    needs: build
+    runs-on: ubuntu-latest
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4

--- a/package.json
+++ b/package.json
@@ -7,7 +7,8 @@
     "dev": "vite",
     "build": "vite build",
     "preview": "vite preview",
-    "gen:sprites": "node tools/generate-sprites.js"
+    "gen:sprites": "node tools/generate-sprites.js",
+    "postbuild": "rm -rf dist/assets && cp -R assets dist/assets"
   },
   "devDependencies": {
     "vite": "^8.0.10"


### PR DESCRIPTION
## Summary\n- Add GitHub Pages workflow that builds on every push and deploys the Vite dist artifact\n- Copy runtime Phaser assets into dist/assets during postbuild so GitHub Pages can serve them\n\n## Verification\n- npm ci\n- npm run build\n- npm run preview -- --host 127.0.0.1 --port 4173\n- curl preview index and title background asset\n\n## Notes\n- Repo visibility has been changed to public.\n- Vite base is already relative, so it works under the /park-slope-heroes/ GitHub Pages subpath.