### PR TITLE
fix(audio): prevent overlapping scene music

### DIFF
--- a/src/audio/SoundManager.js
+++ b/src/audio/SoundManager.js
@@ -1,6 +1,8 @@
 // SoundManager — thin helper attached to a scene for playing SFX and music.
-// Kept minimal: no volume UI, no settings persistence, no mute. Just preload
-// + play. Entities access the active scene's sound_mgr via
+// Music ownership is shared across scenes so the title track cannot survive
+// into gameplay underneath a level track. Kept minimal: no volume UI, no
+// settings persistence, no mute. Just preload + play. Entities access the
+// active scene's sound_mgr via
 // `this.scene.sound_mgr?.playSfx(...)` — optional chaining keeps unit tests
 // (which may construct entities without a scene) from blowing up.
 //
@@ -17,6 +19,9 @@ const SFX_ASSETS = [
 
 const MUSIC_ASSETS = [
   { key: 'music_stage1', path: './assets/audio/music/stage1.ogg' },
+  { key: 'music_stage2', path: './assets/audio/music/stage2.ogg' },
+  { key: 'music_stage3', path: './assets/audio/music/stage3.ogg' },
+  { key: 'music_stage4', path: './assets/audio/music/stage4.ogg' },
   { key: 'music_menu', path: './assets/audio/music/title.ogg' },
 ];
 
@@ -24,6 +29,9 @@ const DEFAULT_SFX_VOLUME = 0.6;
 const DEFAULT_MUSIC_VOLUME = 0.35;
 
 export class SoundManager {
+  static currentMusic = null;
+  static currentMusicKey = null;
+
   constructor(scene) {
     this.scene = scene;
     this.currentMusic = null;
@@ -49,6 +57,13 @@ export class SoundManager {
   }
 
   startMusic(key, config = {}) {
+    const existingMusic = SoundManager.currentMusic;
+    if (existingMusic && SoundManager.currentMusicKey === key) {
+      this.currentMusic = existingMusic;
+      if (!existingMusic.isPlaying) existingMusic.play();
+      return;
+    }
+
     this.stopMusic();
     if (!this.scene.cache.audio.exists(key)) {
       console.warn(`[SoundManager] missing music key: ${key}`);
@@ -59,12 +74,29 @@ export class SoundManager {
       loop: true,
       ...config,
     });
-    this.currentMusic.play();
+    const music = this.currentMusic;
+    SoundManager.currentMusic = music;
+    SoundManager.currentMusicKey = key;
+    music.once?.('destroy', () => {
+      if (SoundManager.currentMusic === music) {
+        SoundManager.currentMusic = null;
+        SoundManager.currentMusicKey = null;
+      }
+    });
+    music.play();
   }
 
   stopMusic() {
-    if (this.currentMusic) {
-      this.currentMusic.stop();
+    const music = SoundManager.currentMusic ?? this.currentMusic;
+    if (!music) return;
+
+    music.stop();
+    music.destroy?.();
+    if (SoundManager.currentMusic === music) {
+      SoundManager.currentMusic = null;
+      SoundManager.currentMusicKey = null;
+    }
+    if (this.currentMusic === music) {
       this.currentMusic = null;
     }
   }

--- a/src/scenes/Stage2.js
+++ b/src/scenes/Stage2.js
@@ -101,10 +101,8 @@ export class Stage2 extends Phaser.Scene {
     this.load.image('rat-king-defeat', './assets/sprites/rat-king-defeat.png');
 
     // Audio — shared SFX/music keys. SoundManager's preload is idempotent on
-    // Phaser's loader so calling it again is cheap. Also load music_stage2
-    // which isn't in SoundManager's default music list yet.
+    // Phaser's loader so calling it again is cheap.
     new SoundManager(this).preload();
-    this.load.audio('music_stage2', './assets/audio/music/stage2.ogg');
   }
 
   create() {

--- a/src/scenes/Stage3.js
+++ b/src/scenes/Stage3.js
@@ -103,10 +103,8 @@ export class Stage3 extends Phaser.Scene {
     }
 
     // Audio — shared SFX/music keys. SoundManager.preload is idempotent on
-    // Phaser's loader. music_stage3 isn't in the default list, so load it
-    // directly (loaderror tolerance above + startMusic no-op below).
+    // Phaser's loader.
     new SoundManager(this).preload();
-    this.load.audio('music_stage3', './assets/audio/music/stage3.ogg');
   }
 
   create() {

--- a/src/scenes/Stage4.js
+++ b/src/scenes/Stage4.js
@@ -103,10 +103,8 @@ export class Stage4 extends Phaser.Scene {
     this.load.image('r-train', './assets/sprites/r-train.png');
 
     // Audio — shared SFX/music keys. SoundManager.preload is idempotent on
-    // Phaser's loader. music_stage4 isn't in the default list, so load it
-    // directly (loaderror tolerance above + startMusic no-op below).
+    // Phaser's loader.
     new SoundManager(this).preload();
-    this.load.audio('music_stage4', './assets/audio/music/stage4.ogg');
   }
 
   create() {


### PR DESCRIPTION
Closes #2\n\n## Summary\n- Share active music ownership across scenes so title/menu music cannot keep playing under stage music\n- Reuse an already-playing track when the next scene requests the same music key\n- Centralize stage music preloading in SoundManager and remove per-stage duplicate loads\n\n## Tests\n- npm ci\n- node SoundManager shared-music smoke test (mocked scene sound manager)\n- npm run build